### PR TITLE
Fix versioning and release behaviour

### DIFF
--- a/.github/workflows/1.checks.yaml
+++ b/.github/workflows/1.checks.yaml
@@ -9,7 +9,42 @@ jobs:
   run-checks:
     runs-on: ubuntu-latest
     steps:
+      - run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Validate `HEAD` commit message
+        run: |
+          git log --graph --decorate --all --max-count=3
+
+          commit_message=$(git log -1 --pretty=%B)
+
+          change_type_entries=("backward-compatible fixes" "backward-compatible features" "backward-incompatible")
+
+          change_type=$(git log -1 --pretty=%B | grep -oP '(?<=^change-type:\s).+' | xargs)
+
+          if [[ -z "$change_type" ]]; then
+              echo "No change-type entry found in commit message. Commit message is invalid. It must contain a line with one of the following entries:"
+              for valid_change_type_entry in "${change_type_entries[@]}"; do
+                  echo "- change-type: $valid_change_type_entry"
+              done
+              exit 1
+          fi
+
+          for valid_change_type_entry in "${change_type_entries[@]}"; do
+              if [[ "$change_type" == "$valid_change_type_entry" ]]; then
+                  echo "Found '${change_type}' change-type in commit message. Commit message is valid."
+                  exit 0
+              fi
+          done
+
+          echo "Found unsupported change type specification '${change_type}' in commit message. Commit message is invalid. It must contain a line with one of the following entries:"
+          for valid_change_type_entry in "${change_type_entries[@]}"; do
+              echo "- change-type: $valid_change_type_entry"
+          done
+          exit 1
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/2.version.yaml
+++ b/.github/workflows/2.version.yaml
@@ -30,7 +30,9 @@ jobs:
         run: |
           # Retrieve the latest git tag, as we will only be processing one delivery line.
           latest_version=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+
           echo "Latest version is $latest_version"
+
           echo "latest_version=$latest_version" >> "$GITHUB_OUTPUT"
 
       - name: Compute next version
@@ -40,17 +42,18 @@ jobs:
           minor=$(echo $latest_version | cut --delimiter=. --fields=2)
           patch=$(echo $latest_version | cut --delimiter=. --fields=3)
 
-          is_new_major_version="false"
+          change_type=$(git log -1 --pretty=%B | grep -oP '(?<=change-type:\s).+' | xargs)
+          echo "Change type is: $change_type"
 
-          change_type=$(git log -1 --pretty=%B | grep -oP '(?<=change-type:\s)\w+')
           if [ "$change_type" == "backward-compatible fixes" ]; then
             patch=$((patch+1))
           elif [ "$change_type" == "backward-compatible features" ]; then
             minor=$((minor+1))
+            patch="0"
           elif [ "$change_type" == "backward-incompatible" ]; then
             major_number=$(echo "$major" | cut --delimiter=v --fields=2)
+
             major="v$((major_number+1))"
-            is_new_major_version="true"
             minor="0"
             patch="0"
           fi
@@ -58,26 +61,34 @@ jobs:
           next_version="$major.$minor.$patch"
           echo "Next version is $next_version"
 
+          echo "next_version_major=$major" >> "$GITHUB_OUTPUT"
+          echo "next_version_minor=$minor" >> "$GITHUB_OUTPUT"
+          echo "next_version_patch=$patch" >> "$GITHUB_OUTPUT"
           echo "next_version=$next_version" >> "$GITHUB_OUTPUT"
-          echo "is_new_major_version=$is_new_major_version" >> "$GITHUB_OUTPUT"
         env:
           latest_version: ${{ steps.get_latest_version.outputs.latest_version }}
 
-      - name: Create reproducible tag
+      - name: Configure git user
         run: |
           git config user.name "workflow-doc-continuous-delivery[bot]"
           git config user.email "workflow-doc-continuous-delivery[bot]@users.noreply.github.com"
 
+      - name: Create reproducible tag
+        run: |
           if git tag -a "$next_version" -m "$next_version"; then
             git push --follow-tags origin "$next_version"
           else
-            echo "Failed to create tag $next_version, it probably already exists"
-          fi
-
-          if [ "$is_new_major_version" == "true"]; then
-            major=$(echo $next_version | cut --delimiter=. --fields=1)
-            git tag -a "$major" -m "$major" && git push --follow-tags origin "$major"
+            echo "Failed to create tag $next_version, does it already exist?"
           fi
         env:
           next_version: "${{ steps.get_next_version.outputs.next_version }}"
-          is_new_major_version: "${{ steps.get_next_version.outputs.is_new_major_version }}"
+
+      - name: Save major version tag
+        run: |
+          if git tag --force a "$next_version_major" -m "Update $next_version_major tag"; then
+            git push origin "$next_version_major" --force
+          else
+            echo "Failed to save updated major tag $next_version_major, does it already exist"
+          fi
+        env:
+          next_version_major: "${{ steps.get_next_version.outputs.next_version_major }}"

--- a/.github/workflows/3.release.yaml
+++ b/.github/workflows/3.release.yaml
@@ -3,8 +3,7 @@ name: Package delivery artifacts & create release
 on:
   push:
     tags:
-      - "v*"
-      - "v*.*.*"
+      - "v+([0-9]).+([0-9]).+([0-9])"
 
 permissions:
   contents: write

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,0 +1,18 @@
+# Contributing
+
+Please keep the [issue tracker](https://github.com/igwejk/workflow-doc/issues) limited to **bug reports** and **improvements**.
+
+## General Questions and Support
+
+If you have questions about how to use `workflow-doc` the best place to ask is in the [Discussions](https://github.com/igwejk/workflow-doc/discussions). Anything that isn't a bug report should be posted as a discussion instead.
+
+## Pull Requests
+
+- Should be submitted from a feature/topic branch (not your `main`)
+- The `HEAD` commit must include a `change-type` line which addresses expectation of backward compatibility in the change.
+
+  When a pull request is merged, the specified `change-type` will influence versioning and release as follows.
+
+  - `change-type: backward-compatible fixes` will cause a patch increment
+  - `change-type: backward-compatible features` will cause a minor increment
+  - `change-type: backward-incompatible` will cause a major version increment

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Execute **`./workflowdoc.py generate /path/to/workflow.yaml`** to generate docum
 
 #### Executing `workflowdoc.py` in a container
 
-If you have `Docker` available you may instead simplify the prerequisite setup by executing **`./workflowdoc.sh --help`**.
+If you have `Docker` available, you may choose to use **`./workflowdoc.sh --help`** which will automatically address prerequisite requirements for you before executing the CLI.
 
 > [!IMPORTANT]
-> Provide a **relative** path as argument to the script when using a container environment for execution.
+> When using the `./workflowdoc.sh` script, provide a **relative** path as argument to the script.
 
 ### GitHub Action wrapper
 


### PR DESCRIPTION
- Create releases for tags matching 'v*.*.*' pattern but not for the 'v<MAJOR>` tags which are mutable by design.
- Correctly capture 'change-type' from commit messages
- Fix computation of next version number
  - patch version should resets on major or minor version bump

change-type: change-type: backward-incompatible
